### PR TITLE
Remove stray space in return type for Converter()

### DIFF
--- a/scripts/grounded_converter.py
+++ b/scripts/grounded_converter.py
@@ -15,7 +15,7 @@ import fire
 
 class Converter(ABC):
 
-    def __init__(self, filepath) - > None:
+    def __init__(self, filepath) -> None:
         super().__init__()
 
         self.filepath = filepath


### PR DESCRIPTION
Looks like there was a stray space char in the return type for the Converter() class in `grounded_converter.py`