### PR TITLE
Remove duplicated NLTK requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ fire==0.4.0
 flask==2.0.2
 flask-Cors==3.0.10
 chardet==3.0.4
-nltk==3.4.1
 beautifulsoup4==4.6.0
 zstandard==0.18.0
 flashtext==2.7


### PR DESCRIPTION
The current requirements.txt file requires two different versions of NLTK which will stop the installation.