### PR TITLE
Removed old nltk version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ fire==0.4.0
 flask==2.0.2
 flask-Cors==3.0.10
 chardet==3.0.4
-nltk==3.4.1
 beautifulsoup4==4.6.0
 zstandard==0.18.0
 flashtext==2.7


### PR DESCRIPTION
Removed old nltk version due to requirements conflict when running pip install -r requirements.txt